### PR TITLE
fix problem when use oidc

### DIFF
--- a/cmd/kubens/main.go
+++ b/cmd/kubens/main.go
@@ -18,6 +18,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -98,7 +99,7 @@ func kubens(query string) (err error) {
 		return err
 	}
 
-	for _, item := range namespaces.Items{
+	for _, item := range namespaces.Items {
 		if item.ObjectMeta.Name == query {
 			return modifyConfig(query)
 		}


### PR DESCRIPTION
I use oidc. So, when I need to refresh token, I got an error. I need to run any command with kubectl to get new token, before I can use kubens
```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1d0c5fb]

goroutine 1 [running]:
k8s.io/client-go/plugin/pkg/client/auth/oidc.(*oidcAuthProvider).idToken(0xc00036bbc0, 0x0, 0x0, 0x0, 0x0)
        /home/rok/pkg/mod/k8s.io/client-go@v0.0.0-20200124032437-bccad466ab89/plugin/pkg/client/auth/oidc/oidc.go:282 +0x6fb
k8s.io/client-go/plugin/pkg/client/auth/oidc.(*roundTripper).RoundTrip(0xc0003945c0, 0xc00029a500, 0x1fab4d7, 0xa, 0xc0003a6360)
        /home/rok/pkg/mod/k8s.io/client-go@v0.0.0-20200124032437-bccad466ab89/plugin/pkg/client/auth/oidc/oidc.go:200 +0x7c
k8s.io/client-go/transport.(*userAgentRoundTripper).RoundTrip(0xc0003945e0, 0xc00029a400, 0xc0003945e0, 0xbf8c0d12291c6a00, 0x12dcfa22e)
        /home/rok/pkg/mod/k8s.io/client-go@v0.0.0-20200124032437-bccad466ab89/transport/round_trippers.go:159 +0x1c0
net/http.send(0xc00029a300, 0x2146e60, 0xc0003945e0, 0xbf8c0d12291c6a00, 0x12dcfa22e, 0x2a9ad80, 0xc0002985c0, 0xbf8c0d12291c6a00, 0x1, 0x0)
        /home/rok/.asdf/installs/golang/1.13.2/go/src/net/http/client.go:250 +0x43a
net/http.(*Client).send(0xc0003905a0, 0xc00029a300, 0xbf8c0d12291c6a00, 0x12dcfa22e, 0x2a9ad80, 0xc0002985c0, 0x0, 0x1, 0x0)
        /home/rok/.asdf/installs/golang/1.13.2/go/src/net/http/client.go:174 +0xfa
net/http.(*Client).do(0xc0003905a0, 0xc00029a300, 0x0, 0x0, 0x0)
        /home/rok/.asdf/installs/golang/1.13.2/go/src/net/http/client.go:641 +0x3ce
net/http.(*Client).Do(...)
        /home/rok/.asdf/installs/golang/1.13.2/go/src/net/http/client.go:509
k8s.io/client-go/rest.(*Request).request(0xc00034a5a0, 0xc0000ff9b0, 0x0, 0x0)
        /home/rok/pkg/mod/k8s.io/client-go@v0.0.0-20200124032437-bccad466ab89/rest/request.go:801 +0x3e9
k8s.io/client-go/rest.(*Request).Do(0xc00034a5a0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/rok/pkg/mod/k8s.io/client-go@v0.0.0-20200124032437-bccad466ab89/rest/request.go:878 +0xd8
k8s.io/client-go/kubernetes/typed/core/v1.(*namespaces).List(0xc00036fc60, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/rok/pkg/mod/k8s.io/client-go@v0.0.0-20200124032437-bccad466ab89/kubernetes/typed/core/v1/namespace.go:86 +0x179
main.kubens(0x7ffeefbff98f, 0x2, 0x4763, 0xc00029e0c0)
        /home/rok/src/github.com/aca/go-kubectx/cmd/kubens/main.go:96 +0xfc
main.main()
        /home/rok/src/github.com/aca/go-kubectx/cmd/kubens/main.go:77 +0x406
```